### PR TITLE
Fix for multiple display use while creating a VM

### DIFF
--- a/MacVM/VMInstance.swift
+++ b/MacVM/VMInstance.swift
@@ -212,7 +212,7 @@ class VMInstance: NSObject, VZVirtualMachineDelegate {
         
         let heightOfToolbar = 0.0
         let graphics = VZMacGraphicsDeviceConfiguration()
-        graphics.displays = NSScreen.screens.count > 0 ? NSScreen.screens.map {
+        graphics.displays = NSScreen.screens.count > 0 && NSScreen.screens.count < 2 ? NSScreen.screens.map {
             VZMacGraphicsDisplayConfiguration(
                 widthInPixels: Int($0.frame.size.width * $0.backingScaleFactor),
                 heightInPixels: Int(($0.frame.size.height - heightOfToolbar) * $0.backingScaleFactor),


### PR DESCRIPTION
This should get you past the bug with multiple displays connected to the system when creating the VM per https://github.com/KhaosT/MacVM/issues/29. I've tested this change on a Mac Studio with two displays connected under 12.4. With the original code, I could not create a VM. With the change, I've created ~5 this afternoon.