### PR TITLE
docs: added setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,12 @@ This project provides an example project for the setup.
 <img width="769" alt="Install" src="https://user-images.githubusercontent.com/1725664/124231322-f68fda80-dac4-11eb-91b8-e29301f50430.png">
 
 <img width="767" alt="Run" src="https://user-images.githubusercontent.com/1725664/124231661-6dc56e80-dac5-11eb-9fea-b6bcd4fb5db6.png">
+
+## Setup 
+
+1. Clone the repository.
+2. Open MacVM.xcodeproj with XCode.
+3. Press run within XCode.
+4. A file picker dialog will show up. Press `New Document`. You do not need to select a file. 
+5. If you get asked for a `ipsw` file you can one [here](https://mrmacintosh.com/apple-silicon-m1-full-macos-restore-ipsw-firmware-files-database/)
+6. Follow the instructions. 


### PR DESCRIPTION
Added short description on how to set up and use the tool.

### List of issues which are fixed by the PR
closes #36 

### Open questions
- I had Apple Configurator 2 already installed - is this mandatory or used at all? 
- Is there a better/more trustworthy source for obtaining the ipsw file than https://mrmacintosh.com/apple-silicon-m1-full-macos-restore-ipsw-firmware-files-database/. I've seen that the site uses Apple CDN, so I'm assuming it's fine. However, I could also compile a list for the readme which provides this information without the need to reference 3rd party sites.